### PR TITLE
Update dependency to work with Itamae to 1.2.x

### DIFF
--- a/itamae-node_env.gemspec
+++ b/itamae-node_env.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "itamae", "~> 1.1.1"
+  spec.add_dependency "itamae", '>= 1.1.1', '< 1.3.0'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Fix runtime dependency to work with Itamae 1.2.x series. It works fine with 1.2.12, at least.
