### PR TITLE
Use gsub

### DIFF
--- a/lib/itamae/node_env.rb
+++ b/lib/itamae/node_env.rb
@@ -10,11 +10,7 @@ module Itamae
 
       case val
       when String
-        if /\Aenv\[(?<key>[^\]]+)\]\z/ =~ val
-          ENV[key]
-        else
-          val
-        end
+        val.gsub(/env\[[a-zA-Z0-9]+\]/) {|h| /env\[(?<key>[^\]]+)\]/ =~ h; ENV[key]}
       when Array
         val.map { |v| apply_env(v, klass) }
       when klass

--- a/lib/itamae/node_env.rb
+++ b/lib/itamae/node_env.rb
@@ -10,7 +10,7 @@ module Itamae
 
       case val
       when String
-        val.gsub(/env\[[a-zA-Z0-9]+\]/) {|h| /env\[(?<key>[^\]]+)\]/ =~ h; ENV[key]}
+        val.gsub(/env\[(\w+?)\]/) { ENV[Regexp.last_match[1]] }
       when Array
         val.map { |v| apply_env(v, klass) }
       when klass


### PR DESCRIPTION
`"env[HOME]/hoge"` 形式に対応していなかったので、対応させました。

```
before
"env[HOME]" => "/User/surume"
"env[HOME]/hogehuga/env[LANG]" => X

after
"env[HOME]" => "/User/surume"
"env[HOME]/hogehuga/env[LANG]" => "/User/surume/hogehuga/ja_JP.UTF-8"
```
